### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "gulp-util": "^3.0.8",
     "jquery": "^3.3.1",
     "normalize.css": "^8.0.1",
-    "npm": "^6.9.0",
     "npm-check-updates": "^3.1.3",
     "owl.carousel": "^2.3.4"
   }


### PR DESCRIPTION

Hello JohnnyBeGreen!

It seems like you have npm as one of your (dev-) dependency in realweb.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
